### PR TITLE
Make more trigger lookups shadow dom aware

### DIFF
--- a/addon/components/basic-dropdown.ts
+++ b/addon/components/basic-dropdown.ts
@@ -179,9 +179,7 @@ export default class BasicDropdown extends Component<Args> {
     this.previousVerticalPosition = this.previousHorizontalPosition = undefined;
     this.isOpen = false;
     this.args.registerAPI && this.args.registerAPI(this.publicAPI);
-    let trigger = document.querySelector(
-      `[data-ebd-id=${this.publicAPI.uniqueId}-trigger]`
-    ) as HTMLElement;
+    let trigger = this._getTriggerElement();
     if (!trigger) {
       return;
     }


### PR DESCRIPTION
As discussed [here](https://github.com/cibernox/ember-basic-dropdown/pull/618#issuecomment-1756462716) this fixes a bug where you couldn't close a dropdown by clicking on the trigger in a shadow dom.

I scanned for other `document.bleh` usage and made sure they are `owner.rootElement` aware as well